### PR TITLE
Calling count() only once, before using 'for' loop

### DIFF
--- a/songs.php
+++ b/songs.php
@@ -1,6 +1,8 @@
 <?php
 
 $songs = glob('*raw');
-for ($x = 0; $x < count($songs); $x++) {
+$songs_length = count($songs);
+
+for ($x = 0; $x < $songs_length; $x++) {
     shuffle($songs);
 }


### PR DESCRIPTION
Just a small fix in songs.php
The for loop is calling count() function on every loop, which may be performance overhead if the songs array was big, and thus calling count() once before the loop and then loop until the given length from count().