### PR TITLE
My telegram org wrapper duplication reduction

### DIFF
--- a/src/danog/MadelineProto/MyTelegramOrgWrapper.php
+++ b/src/danog/MadelineProto/MyTelegramOrgWrapper.php
@@ -35,13 +35,13 @@ class MyTelegramOrgWrapper
         $this->number = $number;
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, $MY_TELEGRAM_URL . '/auth/send_password');
+        curl_setopt($ch, CURLOPT_URL, $this->MY_TELEGRAM_URL.'/auth/send_password');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query(['phone' => $number]));
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_ENCODING, 'gzip, deflate');
 
-        $headers = get_headers("origin", []);
+        $headers = $this->get_headers('origin', []);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
         $result = curl_exec($ch);
@@ -59,47 +59,48 @@ class MyTelegramOrgWrapper
    /**
     * Function for generating curl request headers.
     */
-    private function get_headers($httpType, $cookies) {
-      // Common header flags.
-      $headers = [];
-      $headers[] = 'Dnt: 1';
-      $headers[] = 'Connection: keep-alive';
-      $headers[] = 'Accept-Language: it-IT,it;q=0.8,en-US;q=0.6,en;q=0.4';
-      $headers[] = 'User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36';
+    private function get_headers($httpType, $cookies)
+    {
+        // Common header flags.
+        $headers = [];
+        $headers[] = 'Dnt: 1';
+        $headers[] = 'Connection: keep-alive';
+        $headers[] = 'Accept-Language: it-IT,it;q=0.8,en-US;q=0.6,en;q=0.4';
+        $headers[] = 'User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36';
 
-      // Add additional headers based on the type of request.
-      switch ($httpType) {
-        case "origin":
-          $headers[] = 'Origin: ' . $MY_TELEGRAM_URL;
+        // Add additional headers based on the type of request.
+        switch ($httpType) {
+        case 'origin':
+          $headers[] = 'Origin: '.$this->MY_TELEGRAM_URL;
           $headers[] = 'Accept-Encoding: gzip, deflate, br';
           $headers[] = 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8';
           $headers[] = 'Accept: application/json, text/javascript, */*; q=0.01';
-          $headers[] = 'Referer: ' . $MY_TELEGRAM_URL . '/auth';
+          $headers[] = 'Referer: '.$this->MY_TELEGRAM_URL.'/auth';
           $headers[] = 'X-Requested-With: XMLHttpRequest';
         break;
-        case "refer":
+        case 'refer':
           $headers[] = 'Accept-Encoding: gzip, deflate, sdch, br';
           $headers[] = 'Upgrade-Insecure-Requests: 1';
           $headers[] = 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8';
-          $headers[] = 'Referer: ' . $MY_TELEGRAM_URL;
+          $headers[] = 'Referer: '.$this->MY_TELEGRAM_URL;
           $headers[] = 'Cache-Control: max-age=0';
         break;
-        case "app":
-          $headers[] = 'Origin: ' . $MY_TELEGRAM_URL;
+        case 'app':
+          $headers[] = 'Origin: '.$this->MY_TELEGRAM_URL;
           $headers[] = 'Accept-Encoding: gzip, deflate, br';
           $headers[] = 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8';
           $headers[] = 'Accept: */*';
-          $headers[] = 'Referer: ' . $MY_TELEGRAM_URL . '/apps';
+          $headers[] = 'Referer: '.$this->MY_TELEGRAM_URL.'/apps';
           $headers[] = 'X-Requested-With: XMLHttpRequest';
         break;
         }
 
-      // Add every cookie to the header.
-      foreach ($cookies as $cookie) {
-        $headers[] = 'Cookie: ' . $cookie;
-      }
+        // Add every cookie to the header.
+        foreach ($cookies as $cookie) {
+          $headers[] = 'Cookie: ' . $cookie;
+        }
 
-      return $headers;
+        return $headers;
     }
 
     public function complete_login($password)
@@ -109,13 +110,13 @@ class MyTelegramOrgWrapper
         }
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, $MY_TELEGRAM_URL . '/auth/login');
+        curl_setopt($ch, CURLOPT_URL, $this->MY_TELEGRAM_URL.'/auth/login');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query(['phone' => $this->number, 'random_hash' => $this->hash, 'password' => $password]));
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_ENCODING, 'gzip, deflate');
 
-        $headers = get_headers("origin", []);
+        $headers = $this->get_headers('origin', []);
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
@@ -153,13 +154,13 @@ class MyTelegramOrgWrapper
         }
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, $MY_TELEGRAM_URL . '/apps');
+        curl_setopt($ch, CURLOPT_URL, $this->MY_TELEGRAM_URL.'/apps');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_ENCODING, 'gzip, deflate');
 
         $cookies = [];
         array_push($cookies, 'stel_token='.$this->token);
-        $headers = get_headers("refer", $cookies);
+        $headers = $this->get_headers('refer', $cookies);
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         $result = curl_exec($ch);
@@ -186,13 +187,13 @@ class MyTelegramOrgWrapper
         }
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, $MY_TELEGRAM_URL . '/apps');
+        curl_setopt($ch, CURLOPT_URL, $this->MY_TELEGRAM_URL.'/apps');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_ENCODING, 'gzip, deflate');
 
         $cookies = [];
         array_push($cookies, 'stel_token='.$this->token);
-        $headers = get_headers("refer", $cookies);
+        $headers = $this->get_headers('refer', $cookies);
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         $result = curl_exec($ch);
@@ -226,7 +227,7 @@ class MyTelegramOrgWrapper
 
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, $MY_TELEGRAM_URL . '/apps/create');
+        curl_setopt($ch, CURLOPT_URL, $this->MY_TELEGRAM_URL.'/apps/create');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query(['hash' => $this->creation_hash, 'app_title' => $settings['app_title'], 'app_shortname' => $settings['app_shortname'], 'app_url' => $settings['app_url'], 'app_platform' => $settings['app_platform'], 'app_desc' => $settings['app_desc']]));
         curl_setopt($ch, CURLOPT_POST, 1);
@@ -234,7 +235,7 @@ class MyTelegramOrgWrapper
 
         $cookies = [];
         array_push($cookies, 'stel_token='.$this->token);
-        $headers = get_headers("app", $cookies);
+        $headers = $this->get_headers('app', $cookies);
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
@@ -250,7 +251,7 @@ class MyTelegramOrgWrapper
 
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, $MY_TELEGRAM_URL . '/apps');
+        curl_setopt($ch, CURLOPT_URL, $this->MY_TELEGRAM_URL.'/apps');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
 
@@ -258,7 +259,7 @@ class MyTelegramOrgWrapper
 
         $cookies = [];
         array_push($cookies, 'stel_token='.$this->token);
-        $headers = get_headers("refer", $cookies);
+        $headers = $this->get_headers('refer', $cookies);
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 

--- a/src/danog/MadelineProto/MyTelegramOrgWrapper.php
+++ b/src/danog/MadelineProto/MyTelegramOrgWrapper.php
@@ -56,9 +56,9 @@ class MyTelegramOrgWrapper
         $this->hash = $resulta['random_hash'];
     }
 
-   /**
-    * Function for generating curl request headers.
-    */
+    /**
+     * Function for generating curl request headers.
+     */
     private function get_headers($httpType, $cookies)
     {
         // Common header flags.
@@ -97,7 +97,7 @@ class MyTelegramOrgWrapper
 
         // Add every cookie to the header.
         foreach ($cookies as $cookie) {
-          $headers[] = 'Cookie: ' . $cookie;
+            $headers[] = 'Cookie: ' . $cookie;
         }
 
         return $headers;

--- a/src/danog/MadelineProto/MyTelegramOrgWrapper.php
+++ b/src/danog/MadelineProto/MyTelegramOrgWrapper.php
@@ -18,6 +18,12 @@
 
 namespace danog\MadelineProto;
 
+// For testing
+ini_set('display_errors', 1);
+ini_set('display_startup_errors', 1);
+error_reporting(E_ALL);
+$wrapper = new MyTelegramOrgWrapper(1);
+
 /**
  * Wrapper for my.telegram.org.
  */
@@ -25,6 +31,7 @@ class MyTelegramOrgWrapper
 {
     private $logged = false;
     private $hash = '';
+    final static $MY_TELEGRAM_URL = 'https://my.telegram.org';
 
     public function __construct($number)
     {
@@ -34,23 +41,13 @@ class MyTelegramOrgWrapper
         $this->number = $number;
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, 'https://my.telegram.org/auth/send_password');
+        curl_setopt($ch, CURLOPT_URL, $MY_TELEGRAM_URL . '/auth/send_password');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query(['phone' => $number]));
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_ENCODING, 'gzip, deflate');
 
-        $headers = [];
-        $headers[] = 'Origin: https://my.telegram.org';
-        $headers[] = 'Accept-Encoding: gzip, deflate, br';
-        $headers[] = 'Accept-Language: it-IT,it;q=0.8,en-US;q=0.6,en;q=0.4';
-        $headers[] = 'User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36';
-        $headers[] = 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8';
-        $headers[] = 'Accept: application/json, text/javascript, */*; q=0.01';
-        $headers[] = 'Referer: https://my.telegram.org/auth';
-        $headers[] = 'X-Requested-With: XMLHttpRequest';
-        $headers[] = 'Connection: keep-alive';
-        $headers[] = 'Dnt: 1';
+        $headers = get_headers("origin", []);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
         $result = curl_exec($ch);
@@ -65,6 +62,52 @@ class MyTelegramOrgWrapper
         $this->hash = $resulta['random_hash'];
     }
 
+   /**
+    * Function for generating curl request headers.
+    */
+    private function get_headers($httpType, $cookies) {
+      // Common header flags.
+      $headers = [];
+      $headers[] = 'Dnt: 1';
+      $headers[] = 'Connection: keep-alive';
+      $headers[] = 'Accept-Language: it-IT,it;q=0.8,en-US;q=0.6,en;q=0.4';
+      $headers[] = 'User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36';
+
+      // Add additional headers based on the type of request.
+      switch ($httpType) {
+        case "origin":
+          $headers[] = 'Origin: ' . $MY_TELEGRAM_URL;
+          $headers[] = 'Accept-Encoding: gzip, deflate, br';
+          $headers[] = 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8';
+          $headers[] = 'Accept: application/json, text/javascript, */*; q=0.01';
+          $headers[] = 'Referer: ' . $MY_TELEGRAM_URL . '/auth';
+          $headers[] = 'X-Requested-With: XMLHttpRequest';
+        break;
+        case "refer":
+          $headers[] = 'Accept-Encoding: gzip, deflate, sdch, br';
+          $headers[] = 'Upgrade-Insecure-Requests: 1';
+          $headers[] = 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8';
+          $headers[] = 'Referer: ' . $MY_TELEGRAM_URL;
+          $headers[] = 'Cache-Control: max-age=0';
+        break;
+        case "app":
+          $headers[] = 'Origin: ' . $MY_TELEGRAM_URL;
+          $headers[] = 'Accept-Encoding: gzip, deflate, br';
+          $headers[] = 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8';
+          $headers[] = 'Accept: */*';
+          $headers[] = 'Referer: ' . $MY_TELEGRAM_URL . '/apps';
+          $headers[] = 'X-Requested-With: XMLHttpRequest';
+        break;
+        }
+
+      // Add every cookie to the header.
+      foreach ($cookies as $cookie) {
+        $headers[] = 'Cookie: ' . $cookie;
+      }
+
+      return $headers;
+    }
+
     public function complete_login($password)
     {
         if ($this->logged) {
@@ -72,23 +115,14 @@ class MyTelegramOrgWrapper
         }
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, 'https://my.telegram.org/auth/login');
+        curl_setopt($ch, CURLOPT_URL, $MY_TELEGRAM_URL . '/auth/login');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query(['phone' => $this->number, 'random_hash' => $this->hash, 'password' => $password]));
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_ENCODING, 'gzip, deflate');
 
-        $headers = [];
-        $headers[] = 'Origin: https://my.telegram.org';
-        $headers[] = 'Accept-Encoding: gzip, deflate, br';
-        $headers[] = 'Accept-Language: it-IT,it;q=0.8,en-US;q=0.6,en;q=0.4';
-        $headers[] = 'User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36';
-        $headers[] = 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8';
-        $headers[] = 'Accept: application/json, text/javascript, */*; q=0.01';
-        $headers[] = 'Referer: https://my.telegram.org/auth';
-        $headers[] = 'X-Requested-With: XMLHttpRequest';
-        $headers[] = 'Connection: keep-alive';
-        $headers[] = 'Dnt: 1';
+        $headers = get_headers("origin", []);
+
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13');
@@ -125,20 +159,14 @@ class MyTelegramOrgWrapper
         }
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, 'https://my.telegram.org/apps');
+        curl_setopt($ch, CURLOPT_URL, $MY_TELEGRAM_URL . '/apps');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_ENCODING, 'gzip, deflate');
-        $headers = [];
-        $headers[] = 'Dnt: 1';
-        $headers[] = 'Accept-Encoding: gzip, deflate, sdch, br';
-        $headers[] = 'Accept-Language: it-IT,it;q=0.8,en-US;q=0.6,en;q=0.4';
-        $headers[] = 'Upgrade-Insecure-Requests: 1';
-        $headers[] = 'User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36';
-        $headers[] = 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8';
-        $headers[] = 'Referer: https://my.telegram.org/';
-        $headers[] = 'Cookie: stel_token='.$this->token;
-        $headers[] = 'Connection: keep-alive';
-        $headers[] = 'Cache-Control: max-age=0';
+
+        $cookies = [];
+        array_push($cookies, 'stel_token='.$this->token);
+        $headers = get_headers("refer", $cookies);
+
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         $result = curl_exec($ch);
         if (curl_errno($ch)) {
@@ -164,20 +192,14 @@ class MyTelegramOrgWrapper
         }
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, 'https://my.telegram.org/apps');
+        curl_setopt($ch, CURLOPT_URL, $MY_TELEGRAM_URL . '/apps');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_ENCODING, 'gzip, deflate');
-        $headers = [];
-        $headers[] = 'Dnt: 1';
-        $headers[] = 'Accept-Encoding: gzip, deflate, sdch, br';
-        $headers[] = 'Accept-Language: it-IT,it;q=0.8,en-US;q=0.6,en;q=0.4';
-        $headers[] = 'Upgrade-Insecure-Requests: 1';
-        $headers[] = 'User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36';
-        $headers[] = 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8';
-        $headers[] = 'Referer: https://my.telegram.org/';
-        $headers[] = 'Cookie: stel_token='.$this->token;
-        $headers[] = 'Connection: keep-alive';
-        $headers[] = 'Cache-Control: max-age=0';
+
+        $cookies = [];
+        array_push($cookies, 'stel_token='.$this->token);
+        $headers = get_headers("refer", $cookies);
+
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         $result = curl_exec($ch);
         if (curl_errno($ch)) {
@@ -210,24 +232,16 @@ class MyTelegramOrgWrapper
 
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, 'https://my.telegram.org/apps/create');
+        curl_setopt($ch, CURLOPT_URL, $MY_TELEGRAM_URL . '/apps/create');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query(['hash' => $this->creation_hash, 'app_title' => $settings['app_title'], 'app_shortname' => $settings['app_shortname'], 'app_url' => $settings['app_url'], 'app_platform' => $settings['app_platform'], 'app_desc' => $settings['app_desc']]));
         curl_setopt($ch, CURLOPT_POST, 1);
         curl_setopt($ch, CURLOPT_ENCODING, 'gzip, deflate');
 
-        $headers = [];
-        $headers[] = 'Cookie: stel_token='.$this->token;
-        $headers[] = 'Origin: https://my.telegram.org';
-        $headers[] = 'Accept-Encoding: gzip, deflate, br';
-        $headers[] = 'Accept-Language: it-IT,it;q=0.8,en-US;q=0.6,en;q=0.4';
-        $headers[] = 'User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36';
-        $headers[] = 'Content-Type: application/x-www-form-urlencoded; charset=UTF-8';
-        $headers[] = 'Accept: */*';
-        $headers[] = 'Referer: https://my.telegram.org/apps';
-        $headers[] = 'X-Requested-With: XMLHttpRequest';
-        $headers[] = 'Connection: keep-alive';
-        $headers[] = 'Dnt: 1';
+        $cookies = [];
+        array_push($cookies, 'stel_token='.$this->token);
+        $headers = get_headers("app", $cookies);
+
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
         $result = curl_exec($ch);
@@ -242,23 +256,16 @@ class MyTelegramOrgWrapper
 
         $ch = curl_init();
 
-        curl_setopt($ch, CURLOPT_URL, 'https://my.telegram.org/apps');
+        curl_setopt($ch, CURLOPT_URL, $MY_TELEGRAM_URL . '/apps');
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
 
         curl_setopt($ch, CURLOPT_ENCODING, 'gzip, deflate');
 
-        $headers = [];
-        $headers[] = 'Dnt: 1';
-        $headers[] = 'Accept-Encoding: gzip, deflate, sdch, br';
-        $headers[] = 'Accept-Language: it-IT,it;q=0.8,en-US;q=0.6,en;q=0.4';
-        $headers[] = 'Upgrade-Insecure-Requests: 1';
-        $headers[] = 'User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36';
-        $headers[] = 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8';
-        $headers[] = 'Referer: https://my.telegram.org/';
-        $headers[] = 'Cookie: stel_token='.$this->token;
-        $headers[] = 'Connection: keep-alive';
-        $headers[] = 'Cache-Control: max-age=0';
+        $cookies = [];
+        array_push($cookies, 'stel_token='.$this->token);
+        $headers = get_headers("refer", $cookies);
+
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
 
         $result = curl_exec($ch);

--- a/src/danog/MadelineProto/MyTelegramOrgWrapper.php
+++ b/src/danog/MadelineProto/MyTelegramOrgWrapper.php
@@ -25,7 +25,7 @@ class MyTelegramOrgWrapper
 {
     private $logged = false;
     private $hash = '';
-    final static $MY_TELEGRAM_URL = 'https://my.telegram.org';
+    public static $MY_TELEGRAM_URL = 'https://my.telegram.org';
 
     public function __construct($number)
     {

--- a/src/danog/MadelineProto/MyTelegramOrgWrapper.php
+++ b/src/danog/MadelineProto/MyTelegramOrgWrapper.php
@@ -97,7 +97,7 @@ class MyTelegramOrgWrapper
 
         // Add every cookie to the header.
         foreach ($cookies as $cookie) {
-            $headers[] = 'Cookie: ' . $cookie;
+            $headers[] = 'Cookie: '.$cookie;
         }
 
         return $headers;

--- a/src/danog/MadelineProto/MyTelegramOrgWrapper.php
+++ b/src/danog/MadelineProto/MyTelegramOrgWrapper.php
@@ -18,12 +18,6 @@
 
 namespace danog\MadelineProto;
 
-// For testing
-ini_set('display_errors', 1);
-ini_set('display_startup_errors', 1);
-error_reporting(E_ALL);
-$wrapper = new MyTelegramOrgWrapper(1);
-
 /**
  * Wrapper for my.telegram.org.
  */


### PR DESCRIPTION
This should make this code a bit more manageable, especially: it reduces the duplication present in this code. It moves the construction of the headers to one function, it also defines an often used string as a variable of the class.

Note: I did **not** test this code in any way, as I didn't have the time to.

The syntax seems alright, but testing must be done before merging.