### PR TITLE
Cleanup memory and session files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
         "ext-xml": "*",
         "ext-fileinfo": "*",
         "amphp/amp": "^2.0",
-        "amphp/websocket": "dev-master",
-        "amphp/websocket-client": "dev-master",
+        "amphp/websocket": "dev-master as 1",
+        "amphp/websocket-client": "dev-master as 1",
         "amphp/socket": "^0.10",
+        "amphp/dns": "dev-master#aa1892bdf13b787d759df6f2523e8027a434d927 as v0.9.x-dev",
         "amphp/artax": "dev-master as 3.0.99",
         "amphp/file": "^0.3",
         "amphp/uri": "^0.1.4",
         "amphp/byte-stream": "^1.6",
-        "amphp/dns": "dev-master as v0.9.x-dev",
         "danog/dns-over-https": "^0.1"
     },
     "require-dev": {
@@ -35,7 +35,6 @@
         "ennexa/amp-update-cache": "dev-master",
         "phpunit/phpunit": "^8"
     },
-    "minimum-stability": "dev",
     "suggest": {
         "ext-libtgvoip": "Install the php-libtgvoip extension to make phone calls (https://github.com/danog/php-libtgvoip)"
     },
@@ -50,6 +49,7 @@
         "files": [
             "src/BigIntegor.php",
             "src/YieldReturnValue.php",
+            "src/ReflectionGenerator.php",
             "src/polyfill.php"
         ]
     },

--- a/composer.json
+++ b/composer.json
@@ -20,14 +20,14 @@
         "ext-xml": "*",
         "ext-fileinfo": "*",
         "amphp/amp": "^2.0",
-        "amphp/websocket": "dev-master as 1",
-        "amphp/websocket-client": "dev-master as 1",
+        "amphp/websocket": "dev-master",
+        "amphp/websocket-client": "dev-master",
         "amphp/socket": "^0.10",
-        "amphp/dns": "dev-master#aa1892bdf13b787d759df6f2523e8027a434d927 as v0.9.x-dev",
         "amphp/artax": "dev-master as 3.0.99",
         "amphp/file": "^0.3",
         "amphp/uri": "^0.1.4",
         "amphp/byte-stream": "^1.6",
+        "amphp/dns": "dev-master as v0.9.x-dev",
         "danog/dns-over-https": "^0.1"
     },
     "require-dev": {
@@ -35,6 +35,7 @@
         "ennexa/amp-update-cache": "dev-master",
         "phpunit/phpunit": "^8"
     },
+    "minimum-stability": "dev",
     "suggest": {
         "ext-libtgvoip": "Install the php-libtgvoip extension to make phone calls (https://github.com/danog/php-libtgvoip)"
     },
@@ -49,7 +50,6 @@
         "files": [
             "src/BigIntegor.php",
             "src/YieldReturnValue.php",
-            "src/ReflectionGenerator.php",
             "src/polyfill.php"
         ]
     },

--- a/src/danog/MadelineProto/MTProto.php
+++ b/src/danog/MadelineProto/MTProto.php
@@ -234,9 +234,10 @@ class MTProto extends AsyncConstruct implements TLCallback
     }
 
     /**
-     * Cleanup memory and session file
+     * Cleanup memory and session file.
      */
-    private function cleaunp() {
+    private function cleaunp()
+    {
         $this->referenceDatabase = new ReferenceDatabase($this);
         $this->construct_TL($this->settings['tl_schema']['src'], [$this, $this->referenceDatabase]);
         return $this;

--- a/src/danog/MadelineProto/MTProto.php
+++ b/src/danog/MadelineProto/MTProto.php
@@ -229,7 +229,17 @@ class MTProto extends AsyncConstruct implements TLCallback
 
     public function __sleep()
     {
+        $this->cleaunp();
         return ['supportUser', 'referenceDatabase', 'channel_participants', 'event_handler', 'event_handler_instance', 'loop_callback', 'web_template', 'encrypted_layer', 'settings', 'config', 'authorization', 'authorized', 'rsa_keys', 'dh_config', 'chats', 'last_stored', 'qres', 'got_state', 'channels_state', 'updates', 'updates_key', 'full_chats', 'msg_ids', 'dialog_params', 'datacenter', 'v', 'constructors', 'td_constructors', 'methods', 'td_methods', 'td_descriptions', 'tl_callbacks', 'temp_requested_secret_chats', 'temp_rekeyed_secret_chats', 'secret_chats', 'hook_url', 'storage', 'authorized_dc', 'tos'];
+    }
+
+    /**
+     * Cleanup memory and session file
+     */
+    private function cleaunp() {
+        $this->referenceDatabase = new ReferenceDatabase($this);
+        $this->construct_TL($this->settings['tl_schema']['src'], [$this, $this->referenceDatabase]);
+        return $this;
     }
 
     public function logger($param, $level = Logger::NOTICE, $file = null)

--- a/src/danog/MadelineProto/MTProto.php
+++ b/src/danog/MadelineProto/MTProto.php
@@ -229,7 +229,9 @@ class MTProto extends AsyncConstruct implements TLCallback
 
     public function __sleep()
     {
-        $this->cleaunp();
+        if ($this->settings['serialization']['cleanup_before_serialization']) {
+            $this->cleaunp();
+        }
         return ['supportUser', 'referenceDatabase', 'channel_participants', 'event_handler', 'event_handler_instance', 'loop_callback', 'web_template', 'encrypted_layer', 'settings', 'config', 'authorization', 'authorized', 'rsa_keys', 'dh_config', 'chats', 'last_stored', 'qres', 'got_state', 'channels_state', 'updates', 'updates_key', 'full_chats', 'msg_ids', 'dialog_params', 'datacenter', 'v', 'constructors', 'td_constructors', 'methods', 'td_methods', 'td_descriptions', 'tl_callbacks', 'temp_requested_secret_chats', 'temp_rekeyed_secret_chats', 'secret_chats', 'hook_url', 'storage', 'authorized_dc', 'tos'];
     }
 
@@ -789,7 +791,10 @@ class MTProto extends AsyncConstruct implements TLCallback
             'callback' => 'get_updates_update_handler',
             // Update callback
             'run_callback' => true,
-        ], 'secret_chats' => ['accept_chats' => true], 'serialization' => ['serialization_interval' => 30], 'threading' => [
+        ], 'secret_chats' => ['accept_chats' => true], 'serialization' => [
+            'serialization_interval' => 30,
+            'cleanup_before_serialization' => false,
+        ], 'threading' => [
             'allow_threading' => false,
             // Should I use threading, if it is enabled?
             'handler_workers' => 10,

--- a/src/danog/MadelineProto/MTProto.php
+++ b/src/danog/MadelineProto/MTProto.php
@@ -73,7 +73,7 @@ class MTProto extends AsyncConstruct implements TLCallback
     /*
     const V = 71;
      */
-    const V = 123;
+    const V = 124;
     const RELEASE = '4.0';
     const NOT_LOGGED_IN = 0;
     const WAITING_CODE = 1;

--- a/src/danog/MadelineProto/MTProto.php
+++ b/src/danog/MadelineProto/MTProto.php
@@ -230,7 +230,7 @@ class MTProto extends AsyncConstruct implements TLCallback
     public function __sleep()
     {
         if ($this->settings['serialization']['cleanup_before_serialization']) {
-            $this->cleaunp();
+            $this->cleanup();
         }
         return ['supportUser', 'referenceDatabase', 'channel_participants', 'event_handler', 'event_handler_instance', 'loop_callback', 'web_template', 'encrypted_layer', 'settings', 'config', 'authorization', 'authorized', 'rsa_keys', 'dh_config', 'chats', 'last_stored', 'qres', 'got_state', 'channels_state', 'updates', 'updates_key', 'full_chats', 'msg_ids', 'dialog_params', 'datacenter', 'v', 'constructors', 'td_constructors', 'methods', 'td_methods', 'td_descriptions', 'tl_callbacks', 'temp_requested_secret_chats', 'temp_rekeyed_secret_chats', 'secret_chats', 'hook_url', 'storage', 'authorized_dc', 'tos'];
     }
@@ -238,7 +238,7 @@ class MTProto extends AsyncConstruct implements TLCallback
     /**
      * Cleanup memory and session file.
      */
-    private function cleaunp()
+    private function cleanup()
     {
         $this->referenceDatabase = new ReferenceDatabase($this);
         $this->construct_TL($this->settings['tl_schema']['src'], [$this, $this->referenceDatabase]);


### PR DESCRIPTION
Im running madelineProto inside this service: https://tg.i-c-a.su/ to convert telegram channels to rss or json. Its public so i got many requests. And its inside swoole server so its always in memory.

My session file size goes from 400 kb at start to 100 mb in few days. Memory consumption grow even faster.  Same problem described here: #535 and #474.

Ive checked session file contents and found, that 90% of file is 'tl_callbacks' element, so i made this fix to clean it up before serialisation. 

Only issue is: "Using outdated file reference for location" messages in log, but everything works fine.