### PR TITLE
Fix: Don`t connect to previous instance of same db.

### DIFF
--- a/src/danog/MadelineProto/Db/DbArray.php
+++ b/src/danog/MadelineProto/Db/DbArray.php
@@ -48,7 +48,7 @@ interface DbArray extends DbType, \ArrayAccess, \Countable
      *
      * @psalm-param T $value
      *
-     * @return void
+     * @return Promise
      */
     public function offsetSet($index, $value);
     /**


### PR DESCRIPTION
There is a bug caused by NullCache instances of db. Such instances was treated as another db type and we tried to connect to it. If db settings were changed (password, port, host) then it will cause error, because old instance stored old settings.