### PR TITLE
Copy existing log file before truncate process

### DIFF
--- a/src/danog/MadelineProto/Logger.php
+++ b/src/danog/MadelineProto/Logger.php
@@ -285,6 +285,7 @@ class Logger
                     static function () use ($maxSize, $optional, &$stdout) {
                         \clearstatcache(true, $optional);
                         if (\file_exists($optional) && \filesize($optional) >= $maxSize) {
+                            \copy($optional, $optional.'.old');
                             \ftruncate($stdout->getResource(), 0);
                             self::log("Automatically truncated logfile to $maxSize");
                         }


### PR DESCRIPTION
It would be great to keep the most recent one each time especially if we have custom logger settings.