### PR TITLE
Fix decompression of photoStrippedSize

### DIFF
--- a/src/danog/MadelineProto/Tools.php
+++ b/src/danog/MadelineProto/Tools.php
@@ -842,7 +842,7 @@ abstract class Tools extends StrTools
             "\x3f\x00";
         static $footer = "\xff\xd9";
         $header[164] = $stripped[1];
-        $header[165] = $stripped[2];
+        $header[166] = $stripped[2];
         return $header.\substr($stripped, 3).$footer;
     }
     /**


### PR DESCRIPTION
The decompression of the thumbnail in the photoStrippedSize type ("inflated" field in https://docs.madelineproto.xyz/API_docs/constructors/photoStrippedSize.html) doesn't work properly.
Here the fix.