### PR TITLE
Fix set level of logger

### DIFF
--- a/src/danog/MadelineProto/Settings/Logger.php
+++ b/src/danog/MadelineProto/Settings/Logger.php
@@ -191,7 +191,7 @@ final class Logger extends SettingsAbstract
      */
     public function setLevel(int $level): self
     {
-        $this->level = \max($level, MadelineProtoLogger::NOTICE);
+        $this->level = $level;
 
         return $this;
     }


### PR DESCRIPTION
Fixed error: cannot set log level to LEVEL_FATAL or LEVEL_ERROR