### PR TITLE
Fix: access to empty property

### DIFF
--- a/src/DataCenterConnection.php
+++ b/src/DataCenterConnection.php
@@ -587,7 +587,7 @@ final class DataCenterConnection implements JsonSerializable
      */
     public function waitGetConnection(): Connection
     {
-        if (empty($this->availableConnections)) {
+        if (empty($this->availableConnections) && !empty($this->connectionsPromise)) {
             $this->connectionsPromise->await();
         }
         return $this->getConnection();


### PR DESCRIPTION
```
telegram-api-server        | Fatal error: Uncaught Error: Typed property danog\MadelineProto\DataCenterConnection::$connectionsPromise must not be accessed before initialization in /app-host-link/vendor/danog/madelineproto/src/DataCenterConnection.php:591
telegram-api-server        | Stack trace:
telegram-api-server        | #0 /app-host-link/vendor/danog/madelineproto/src/DataCenterConnection.php(153): danog\MadelineProto\DataCenterConnection->waitGetConnection()
telegram-api-server        | #1 /app-host-link/vendor/amphp/amp/src/functions.php(34): danog\MadelineProto\DataCenterConnection->initAuthorization()
telegram-api-server        | #2 /app-host-link/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(406): Amp\{closure}(NULL, NULL, Array)
telegram-api-server        | #3 /app-host-link/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(542): Revolt\EventLoop\Internal\AbstractDriver->invokeMicrotasks()
telegram-api-server        | #4 [internal function]: Revolt\EventLoop\Internal\AbstractDriver->Revolt\EventLoop\Internal\{closure}()
telegram-api-server        | #5 /app-host-link/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(478): Fiber->resume()
telegram-api-server        | #6 /app-host-link/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(533): Revolt\EventLoop\Internal\AbstractDriver->invokeCallbacks()
telegram-api-server        | #7 [internal function]: Revolt\EventLoop\Internal\AbstractDriver->Revolt\EventLoop\Internal\{closure}()
telegram-api-server        | #8 /app-host-link/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(86): Fiber->resume()
telegram-api-server        | #9 /app-host-link/vendor/revolt/event-loop/src/EventLoop/Internal/DriverSuspension.php(97): Revolt\EventLoop\Internal\AbstractDriver->Revolt\EventLoop\Internal\{closure}()
telegram-api-server        | #10 /app-host-link/vendor/amphp/amp/src/Future.php(251): Revolt\EventLoop\Internal\DriverSuspension->suspend()
telegram-api-server        | #11 /app-host-link/vendor/danog/madelineproto/src/MTProto.php(1184): Amp\Future->await()
telegram-api-server        | #12 /app-host-link/vendor/danog/madelineproto/src/APIWrapper.php(98): danog\MadelineProto\MTProto->waitForInit()
telegram-api-server        | #13 /app-host-link/vendor/danog/madelineproto/src/MTProto.php(561): danog\MadelineProto\APIWrapper->serialize()
telegram-api-server        | #14 /app-host-link/vendor/danog/madelineproto/src/Shutdown.php(60): danog\MadelineProto\MTProto::serializeAll()
telegram-api-server        | #15 /app-host-link/vendor/danog/madelineproto/src/Shutdown.php(71): danog\MadelineProto\Shutdown::shutdown()
telegram-api-server        | #16 [internal function]: danog\MadelineProto\Shutdown::danog\MadelineProto\{closure}()
telegram-api-server        | #17 {main}

```