### PR TITLE
Fix: access to empty property

### DIFF
--- a/src/DataCenterConnection.php
+++ b/src/DataCenterConnection.php
@@ -588,6 +588,9 @@ final class DataCenterConnection implements JsonSerializable
     public function waitGetConnection(): Connection
     {
         if (empty($this->availableConnections)) {
+            if (empty($this->connectionsPromise)) {
+                $this->reconnect();
+            }
             $this->connectionsPromise->await();
         }
         return $this->getConnection();


### PR DESCRIPTION
```
Fatal error: Uncaught Error: Typed property danog\MadelineProto\DataCenterConnection::$connectionsPromise must not be accessed before initialization in /app-host-link/vendor/danog/madelineproto/src/DataCenterConnection.php:591
```