### PR TITLE
Fix: safari requires one big range for video

### DIFF
--- a/src/MTProtoTools/ResponseInfo.php
+++ b/src/MTProtoTools/ResponseInfo.php
@@ -100,6 +100,13 @@ final class ResponseInfo
         }
         $seek_start = empty($seek_start) ? 0 : \abs(\intval($seek_start));
 
+        //Safari video streaming fix
+        $length = ($seek_end - $seek_start + 1);
+        $maxChunkSize = 10 * 1024 ** 2;
+        if ($length > $maxChunkSize) {
+            $seek_end = $seek_start + $maxChunkSize - 1;
+        }
+
         $this->serve = $method !== 'HEAD';
         if ($seek_start > 0 || $seek_end < $size - 1) {
             $this->code = HttpStatus::PARTIAL_CONTENT;


### PR DESCRIPTION
Before: 
<img width="1273" alt="Снимок экрана 2023-04-11 в 02 10 18" src="https://user-images.githubusercontent.com/34161928/231022779-61e32803-c302-464a-bdb6-9e99f406db2d.png">

After: 

<img width="1262" alt="image" src="https://user-images.githubusercontent.com/34161928/231022864-5a6c1fd0-92f5-4297-b037-700ee06c7901.png">

