### PR TITLE
Prevent undefined index

### DIFF
--- a/src/Conversion.php
+++ b/src/Conversion.php
@@ -103,6 +103,10 @@ final class Conversion
         $sqlite = new PDO("sqlite:$session");
         $session = $sqlite->query("SELECT * FROM sessions")->fetchAll(PDO::FETCH_ASSOC)[0];
 
+        if (!isset ($session['test_mode'])) {
+            $session['test_mode'] = false;
+        }
+        
         $settingsFull = new Settings;
         if ($settings) {
             $settingsFull->merge($settings);


### PR DESCRIPTION
Prevent error "Undefined array key "test_mode" in Conversion.php:114" for pyrogram conversion.