### PR TITLE
Ensure actions are broadcasted to the group, not directed to the sender

### DIFF
--- a/src/EventHandler/AbstractMessage.php
+++ b/src/EventHandler/AbstractMessage.php
@@ -867,7 +867,7 @@ abstract class AbstractMessage extends Update implements SimpleFilters
         return $this->getClient()->methodCallAsyncRead(
             'messages.setTyping',
             [
-                'peer' => $this->senderId,
+                'peer' => $this->chatId,
                 'top_msg_id' => $this->topicId,
                 'action' => $action,
             ],


### PR DESCRIPTION
When using `setAction()` with the bot in a group, the bot needs to send the action to the group shared between the sender and the bot, rather than sending it specifically to the sender.