### PR TITLE
Add support for some bot commands + Fix TextWithEntities

### DIFF
--- a/src/EventHandler/Filter/FilterBotCommand.php
+++ b/src/EventHandler/Filter/FilterBotCommand.php
@@ -19,6 +19,7 @@ namespace danog\MadelineProto\EventHandler\Filter;
 use Attribute;
 use danog\MadelineProto\EventHandler;
 use danog\MadelineProto\EventHandler\CommandType;
+use danog\MadelineProto\EventHandler\Filter\Combinator\FiltersOr;
 use danog\MadelineProto\EventHandler\Message;
 use danog\MadelineProto\EventHandler\Update;
 use Webmozart\Assert\Assert;
@@ -35,7 +36,10 @@ class FilterBotCommand extends Filter
         $info = $API->getSelf();
         Assert::true($info['bot'], 'This filter can only be used by bots!');
         $this->usernames ??= array_column($info['usernames'] ?? '', 'username') ?? [$info['username'] ?? ''];
-        return $this;
+        foreach ($this->usernames as $username) {
+            $filters[] = new FilterCommand($this->command);
+        }
+        return new FiltersOr(...$filters);
     }
     public function __construct(private readonly string $command)
     {

--- a/src/EventHandler/Filter/FilterBotCommand.php
+++ b/src/EventHandler/Filter/FilterBotCommand.php
@@ -24,7 +24,7 @@ use danog\MadelineProto\EventHandler\Update;
 use Webmozart\Assert\Assert;
 
 /**
- * Allow only messages containing the specified command.
+ * Allow only messages containing the specified command, optionally postfixed with the bot's username
  */
 #[Attribute(Attribute::TARGET_METHOD)]
 class FilterBotCommand extends Filter
@@ -34,7 +34,7 @@ class FilterBotCommand extends Filter
     {
         $info = $API->getSelf();
         Assert::true($info['bot'], 'This filter can only be used by bots!');
-        $this->usernames ??= array_column($info['usernames'], 'username') ?? [$info['username'] ?? ''];
+        $this->usernames ??= array_column($info['usernames'] ?? '', 'username') ?? [$info['username'] ?? ''];
         return $this;
     }
     public function __construct(private readonly string $command)

--- a/src/EventHandler/Filter/FilterBotCommand.php
+++ b/src/EventHandler/Filter/FilterBotCommand.php
@@ -18,6 +18,7 @@ namespace danog\MadelineProto\EventHandler\Filter;
 
 use AssertionError;
 use Attribute;
+use danog\MadelineProto\API;
 use danog\MadelineProto\EventHandler;
 use danog\MadelineProto\EventHandler\CommandType;
 use danog\MadelineProto\EventHandler\Filter\Combinator\FiltersOr;
@@ -32,11 +33,9 @@ class FilterBotCommand extends Filter
 {
     public function initialize(EventHandler $API): Filter
     {
-        $info = $API->getSelf();
-        Assert::true($info['bot'], 'This filter can only be used by bots!');
-        $usernames ??= array_column($info['usernames'] ?? '', 'username') ?? [$info['username'] ?? ''];
-        foreach ($usernames as $username) {
-            $filters[] = new FilterCommand("{$this->command}@$username",[CommandType::SLASH]);
+        Assert::true($API->isSelfBot(), 'This filter can only be used by bots!');
+        foreach ($API->getInfo('me', API::INFO_TYPE_USERNAMES) as $username) {
+            $filters[] = new FilterCommand("{$this->command}@$username", [CommandType::SLASH]);
         }
         if(!empty($filters)) {
             return new FiltersOr(...$filters);

--- a/src/EventHandler/Filter/FilterBotCommand.php
+++ b/src/EventHandler/Filter/FilterBotCommand.php
@@ -27,7 +27,7 @@ use Webmozart\Assert\Assert;
  * Allow only messages containing the specified command.
  */
 #[Attribute(Attribute::TARGET_METHOD)]
-class FilterSingleCommand extends Filter
+class FilterBotCommand extends Filter
 {
     private readonly array $usernames;
     public function initialize(EventHandler $API): Filter

--- a/src/EventHandler/Filter/FilterBotCommand.php
+++ b/src/EventHandler/Filter/FilterBotCommand.php
@@ -45,12 +45,9 @@ class FilterBotCommand extends Filter
 
     public function apply(Update $update): bool
     {
-        if($update instanceof Message) {
-            preg_match("/^(\w+)@([a-z](?:[a-z0-9]*(?:_[a-z0-9]+)?)*)$/i", $update->message, $matches);
-            if(\in_array($matches[2], $this->usernames, true)) {
-                return (new FilterCommand($this->command, [CommandType::SLASH]))->apply($update);
-            }
-            return false;
+        $update instanceof Message && preg_match("/^(\w+)@([a-z](?:[a-z0-9]*(?:_[a-z0-9]+)?)*)$/i", $update->message, $matches);
+        if(\in_array($matches[2] ?? '', $this->usernames, true)) {
+            return (new FilterCommand($this->command, [CommandType::SLASH]))->apply($update);
         }
         return false;
     }

--- a/src/EventHandler/Filter/FilterBotCommand.php
+++ b/src/EventHandler/Filter/FilterBotCommand.php
@@ -34,10 +34,10 @@ class FilterBotCommand extends Filter
     public function initialize(EventHandler $API): Filter
     {
         Assert::true($API->isSelfBot(), 'This filter can only be used by bots!');
-        foreach ($API->getInfo('me', API::INFO_TYPE_USERNAMES) as $_) {
-            $filters[] = new FilterCommand($this->command, [CommandType::SLASH]);
+        $filters = [new FilterCommand($this->command, [CommandType::SLASH])];
+        foreach ($API->getInfo('me', API::INFO_TYPE_USERNAMES) as $username) {
+            $filters[] = new FilterCommand("{$this->command}@$username", [CommandType::SLASH]);
         }
-        Assert::notEmpty($filters ?? [], 'Filter commands must not be empty.');
         return new FiltersOr(...$filters);
     }
     public function __construct(private readonly string $command)

--- a/src/EventHandler/Filter/FilterBotCommand.php
+++ b/src/EventHandler/Filter/FilterBotCommand.php
@@ -34,13 +34,11 @@ class FilterBotCommand extends Filter
     public function initialize(EventHandler $API): Filter
     {
         Assert::true($API->isSelfBot(), 'This filter can only be used by bots!');
-        foreach ($API->getInfo('me', API::INFO_TYPE_USERNAMES) as $username) {
-            $filters[] = new FilterCommand("{$this->command}@$username", [CommandType::SLASH]);
+        foreach ($API->getInfo('me', API::INFO_TYPE_USERNAMES) as $_) {
+            $filters[] = new FilterCommand($this->command, [CommandType::SLASH]);
         }
-        if(!empty($filters)) {
-            return new FiltersOr(...$filters);
-        }
-        return parent::initialize($API);
+        Assert::notEmpty($filters ?? [], 'Filter commands must not be empty.');
+        return new FiltersOr(...$filters);
     }
     public function __construct(private readonly string $command)
     {

--- a/src/EventHandler/Filter/FilterBotCommand.php
+++ b/src/EventHandler/Filter/FilterBotCommand.php
@@ -29,16 +29,15 @@ use Webmozart\Assert\Assert;
 #[Attribute(Attribute::TARGET_METHOD)]
 class FilterBotCommand extends Filter
 {
-    private readonly array $usernames;
     public function initialize(EventHandler $API): Filter
     {
         $info = $API->getSelf();
         Assert::true($info['bot'], 'This filter can only be used by bots!');
-        $this->usernames ??= array_column($info['usernames'] ?? '', 'username') ?? [$info['username'] ?? ''];
-        foreach ($this->usernames as $_) {
+        $usernames ??= array_column($info['usernames'] ?? '', 'username') ?? [$info['username'] ?? ''];
+        foreach ($usernames as $_) {
             $filters[] = new FilterCommand($this->command);
         }
-        if(!empty($filters)){
+        if(!empty($filters)) {
             return new FiltersOr(...$filters);
         }
         return parent::initialize($API);

--- a/src/EventHandler/Filter/FilterBotCommand.php
+++ b/src/EventHandler/Filter/FilterBotCommand.php
@@ -16,11 +16,10 @@
 
 namespace danog\MadelineProto\EventHandler\Filter;
 
+use AssertionError;
 use Attribute;
 use danog\MadelineProto\EventHandler;
-use danog\MadelineProto\EventHandler\CommandType;
 use danog\MadelineProto\EventHandler\Filter\Combinator\FiltersOr;
-use danog\MadelineProto\EventHandler\Message;
 use danog\MadelineProto\EventHandler\Update;
 use Webmozart\Assert\Assert;
 
@@ -36,10 +35,13 @@ class FilterBotCommand extends Filter
         $info = $API->getSelf();
         Assert::true($info['bot'], 'This filter can only be used by bots!');
         $this->usernames ??= array_column($info['usernames'] ?? '', 'username') ?? [$info['username'] ?? ''];
-        foreach ($this->usernames as $username) {
+        foreach ($this->usernames as $_) {
             $filters[] = new FilterCommand($this->command);
         }
-        return new FiltersOr(...$filters);
+        if(!empty($filters)){
+            return new FiltersOr(...$filters);
+        }
+        return parent::initialize($API);
     }
     public function __construct(private readonly string $command)
     {
@@ -47,10 +49,6 @@ class FilterBotCommand extends Filter
 
     public function apply(Update $update): bool
     {
-        $update instanceof Message && preg_match("/^(\w+)@([a-z](?:[a-z0-9]*(?:_[a-z0-9]+)?)*)$/i", $update->message, $matches);
-        if(\in_array($matches[2] ?? '', $this->usernames, true)) {
-            return (new FilterCommand($this->command, [CommandType::SLASH]))->apply($update);
-        }
-        return false;
+        throw new AssertionError("Unreachable!");
     }
 }

--- a/src/EventHandler/Filter/FilterBotCommand.php
+++ b/src/EventHandler/Filter/FilterBotCommand.php
@@ -21,12 +21,10 @@ use danog\MadelineProto\EventHandler;
 use danog\MadelineProto\EventHandler\CommandType;
 use danog\MadelineProto\EventHandler\Message;
 use danog\MadelineProto\EventHandler\Update;
-use danog\MadelineProto\RPCError\FloodWaitError;
-use danog\MadelineProto\RPCErrorException;
 use Webmozart\Assert\Assert;
 
 /**
- * Allow only messages containing the specified command, optionally postfixed with the bot's username
+ * Allow only messages containing the specified command, optionally postfixed with the bot's username.
  */
 #[Attribute(Attribute::TARGET_METHOD)]
 class FilterBotCommand extends Filter

--- a/src/EventHandler/Filter/FilterBotCommand.php
+++ b/src/EventHandler/Filter/FilterBotCommand.php
@@ -19,6 +19,7 @@ namespace danog\MadelineProto\EventHandler\Filter;
 use AssertionError;
 use Attribute;
 use danog\MadelineProto\EventHandler;
+use danog\MadelineProto\EventHandler\CommandType;
 use danog\MadelineProto\EventHandler\Filter\Combinator\FiltersOr;
 use danog\MadelineProto\EventHandler\Update;
 use Webmozart\Assert\Assert;
@@ -34,8 +35,8 @@ class FilterBotCommand extends Filter
         $info = $API->getSelf();
         Assert::true($info['bot'], 'This filter can only be used by bots!');
         $usernames ??= array_column($info['usernames'] ?? '', 'username') ?? [$info['username'] ?? ''];
-        foreach ($usernames as $_) {
-            $filters[] = new FilterCommand($this->command);
+        foreach ($usernames as $username) {
+            $filters[] = new FilterCommand("{$this->command}@$username",[CommandType::SLASH]);
         }
         if(!empty($filters)) {
             return new FiltersOr(...$filters);

--- a/src/EventHandler/Filter/FilterBotCommand.php
+++ b/src/EventHandler/Filter/FilterBotCommand.php
@@ -21,6 +21,8 @@ use danog\MadelineProto\EventHandler;
 use danog\MadelineProto\EventHandler\CommandType;
 use danog\MadelineProto\EventHandler\Message;
 use danog\MadelineProto\EventHandler\Update;
+use danog\MadelineProto\RPCError\FloodWaitError;
+use danog\MadelineProto\RPCErrorException;
 use Webmozart\Assert\Assert;
 
 /**

--- a/src/EventHandler/Filter/FilterSingleCommand.php
+++ b/src/EventHandler/Filter/FilterSingleCommand.php
@@ -44,7 +44,7 @@ class FilterSingleCommand extends Filter
     public function apply(Update $update): bool
     {
         if($update instanceof Message) {
-            preg_match("/^\/(\w+)@([a-zA-Z](?:[a-zA-Z0-9]*(?:_[a-zA-Z0-9]+)?)*)$/", $update->message, $matches);
+            preg_match("/^(\w+)@([a-z](?:[a-z0-9]*(?:_[a-z0-9]+)?)*)$/i", $update->message, $matches);
             if(\in_array($matches[2], $this->usernames, true)) {
                 return (new FilterCommand($this->command, [CommandType::SLASH]))->apply($update);
             }

--- a/src/EventHandler/Filter/FilterSingleCommand.php
+++ b/src/EventHandler/Filter/FilterSingleCommand.php
@@ -44,8 +44,7 @@ class FilterSingleCommand extends Filter
     public function apply(Update $update): bool
     {
         if($update instanceof Message) {
-            Assert::true(preg_match("/^\/(\w+)@([a-zA-Z](?:[a-zA-Z0-9]*(?:_[a-zA-Z0-9]+)?)*)$/", $update->message, $matches) === 1, "An invalid command was specified!");
-            Assert::true($matches[2] >= 3 && $matches[2] <= 32, "Username must contain between 3 and 32 characters!");
+            preg_match("/^\/(\w+)@([a-zA-Z](?:[a-zA-Z0-9]*(?:_[a-zA-Z0-9]+)?)*)$/", $update->message, $matches);
             if(\in_array($matches[2], $this->usernames, true)) {
                 return (new FilterCommand($this->command, [CommandType::SLASH]))->apply($update);
             }

--- a/src/EventHandler/Filter/FilterSingleCommand.php
+++ b/src/EventHandler/Filter/FilterSingleCommand.php
@@ -33,8 +33,8 @@ class FilterSingleCommand extends Filter
     public function initialize(EventHandler $API): Filter
     {
         $info = $API->getSelf();
-        Assert::true($info['bot'],'This filter can only be used by bots!');
-        $this->usernames = $info['usernames'] ?? [$info['username']] ?? [];
+        Assert::true($info['bot'], 'This filter can only be used by bots!');
+        $this->usernames ??= array_column($info['usernames'], 'username') ?? [$info['username']] ?? [];
         return $this;
     }
     public function __construct(private readonly string $command)
@@ -43,11 +43,11 @@ class FilterSingleCommand extends Filter
 
     public function apply(Update $update): bool
     {
-        if($update instanceof Message){
-            Assert::true(preg_match("/^\/(\w+)@([a-zA-Z](?:[a-zA-Z0-9]*(?:_[a-zA-Z0-9]+)?)*)$/", $update->message,$matches) === 1, "An invalid command was specified!");
+        if($update instanceof Message) {
+            Assert::true(preg_match("/^\/(\w+)@([a-zA-Z](?:[a-zA-Z0-9]*(?:_[a-zA-Z0-9]+)?)*)$/", $update->message, $matches) === 1, "An invalid command was specified!");
             Assert::true($matches[2] >= 3 && $matches[2] <= 32, "Username must contain between 3 and 32 characters!");
-            if(in_array($matches[2], $this->usernames, true)){
-                return (new FilterCommand($this->command,[CommandType::SLASH]))->apply($update);
+            if(\in_array($matches[2], $this->usernames, true)) {
+                return (new FilterCommand($this->command, [CommandType::SLASH]))->apply($update);
             }
             return false;
         }

--- a/src/EventHandler/Filter/FilterSingleCommand.php
+++ b/src/EventHandler/Filter/FilterSingleCommand.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of MadelineProto.
+ * MadelineProto is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ * MadelineProto is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU General Public License along with MadelineProto.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author    Mahdi <mahdi.talaee1379@gmail.com>
+ * @copyright 2016-2023 Mahdi <mahdi.talaee1379@gmail.com>
+ * @license   https://opensource.org/licenses/AGPL-3.0 AGPLv3
+ * @link https://docs.madelineproto.xyz MadelineProto documentation
+ */
+
+namespace danog\MadelineProto\EventHandler\Filter;
+
+use Attribute;
+use danog\MadelineProto\EventHandler;
+use danog\MadelineProto\EventHandler\CommandType;
+use danog\MadelineProto\EventHandler\Message;
+use danog\MadelineProto\EventHandler\Update;
+use Webmozart\Assert\Assert;
+
+/**
+ * Allow only messages containing the specified command.
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+class FilterSingleCommand extends Filter
+{
+    private readonly array $usernames;
+    public function initialize(EventHandler $API): Filter
+    {
+        $info = $API->getSelf();
+        Assert::true($info['bot'],'This filter can only be used by bots!');
+        $this->usernames = $info['usernames'] ?? [$info['username']] ?? [];
+        return $this;
+    }
+    public function __construct(private readonly string $command)
+    {
+    }
+
+    public function apply(Update $update): bool
+    {
+        if($update instanceof Message){
+            Assert::true(preg_match("/^\/(\w+)@([a-zA-Z](?:[a-zA-Z0-9]*(?:_[a-zA-Z0-9]+)?)*)$/", $update->message,$matches) === 1, "An invalid command was specified!");
+            Assert::true($matches[2] >= 3 && $matches[2] <= 32, "Username must contain between 3 and 32 characters!");
+            if(in_array($matches[2], $this->usernames, true)){
+                return (new FilterCommand($this->command,[CommandType::SLASH]))->apply($update);
+            }
+            return false;
+        }
+        return false;
+    }
+}

--- a/src/EventHandler/Filter/FilterSingleCommand.php
+++ b/src/EventHandler/Filter/FilterSingleCommand.php
@@ -34,7 +34,7 @@ class FilterSingleCommand extends Filter
     {
         $info = $API->getSelf();
         Assert::true($info['bot'], 'This filter can only be used by bots!');
-        $this->usernames ??= array_column($info['usernames'], 'username') ?? [$info['username']] ?? [];
+        $this->usernames ??= array_column($info['usernames'], 'username') ?? [$info['username'] ?? ''];
         return $this;
     }
     public function __construct(private readonly string $command)

--- a/src/EventHandler/Message.php
+++ b/src/EventHandler/Message.php
@@ -199,7 +199,8 @@ abstract class Message extends AbstractMessage
         if ($this->commandType = CommandType::tryFrom($this->message[0] ?? '')) {
             $space = strpos($this->message, ' ', 1) ?: \strlen($this->message);
             $args = explode(' ', substr($this->message, $space+1));
-            $this->command = substr($cmd = substr($this->message, 1, $space-1), 0, strpos($cmd, "@"));
+            $length = ($len = strpos($cmd = substr($this->message ,1, $space-1), "@")) ? $len : $space-1;
+            $this->command = substr($cmd, 0,$length);
             $this->commandArgs = $args === [''] ? [] : $args;
         } else {
             $this->command = null;

--- a/src/EventHandler/Message.php
+++ b/src/EventHandler/Message.php
@@ -199,7 +199,7 @@ abstract class Message extends AbstractMessage
         if ($this->commandType = CommandType::tryFrom($this->message[0] ?? '')) {
             $space = strpos($this->message, ' ', 1) ?: \strlen($this->message);
             $args = explode(' ', substr($this->message, $space+1));
-            $this->command = explode('@', substr($this->message, 1, $space-1))[0];
+            $this->command = substr($cmd = substr($this->message, 1, $space-1),0,strpos($cmd,"@"));
             $this->commandArgs = $args === [''] ? [] : $args;
         } else {
             $this->command = null;

--- a/src/EventHandler/Message.php
+++ b/src/EventHandler/Message.php
@@ -199,7 +199,7 @@ abstract class Message extends AbstractMessage
         if ($this->commandType = CommandType::tryFrom($this->message[0] ?? '')) {
             $space = strpos($this->message, ' ', 1) ?: \strlen($this->message);
             $args = explode(' ', substr($this->message, $space+1));
-            $this->command = substr($this->message, 1, $space-1);
+            $this->command = explode('@',substr($this->message, 1, $space-1))[0];
             $this->commandArgs = $args === [''] ? [] : $args;
         } else {
             $this->command = null;

--- a/src/EventHandler/Message.php
+++ b/src/EventHandler/Message.php
@@ -199,7 +199,7 @@ abstract class Message extends AbstractMessage
         if ($this->commandType = CommandType::tryFrom($this->message[0] ?? '')) {
             $space = strpos($this->message, ' ', 1) ?: \strlen($this->message);
             $args = explode(' ', substr($this->message, $space+1));
-            $this->command = substr($cmd = substr($this->message, 1, $space-1),0,strpos($cmd,"@"));
+            $this->command = substr($cmd = substr($this->message, 1, $space-1), 0, strpos($cmd, "@"));
             $this->commandArgs = $args === [''] ? [] : $args;
         } else {
             $this->command = null;

--- a/src/EventHandler/Message.php
+++ b/src/EventHandler/Message.php
@@ -199,8 +199,8 @@ abstract class Message extends AbstractMessage
         if ($this->commandType = CommandType::tryFrom($this->message[0] ?? '')) {
             $space = strpos($this->message, ' ', 1) ?: \strlen($this->message);
             $args = explode(' ', substr($this->message, $space+1));
-            $length = ($len = strpos($cmd = substr($this->message ,1, $space-1), "@")) ? $len : $space-1;
-            $this->command = substr($cmd, 0,$length);
+            $length = ($len = strpos($cmd = substr($this->message, 1, $space-1), "@")) ? $len : $space-1;
+            $this->command = substr($cmd, 0, $length);
             $this->commandArgs = $args === [''] ? [] : $args;
         } else {
             $this->command = null;

--- a/src/EventHandler/Message.php
+++ b/src/EventHandler/Message.php
@@ -199,7 +199,7 @@ abstract class Message extends AbstractMessage
         if ($this->commandType = CommandType::tryFrom($this->message[0] ?? '')) {
             $space = strpos($this->message, ' ', 1) ?: \strlen($this->message);
             $args = explode(' ', substr($this->message, $space+1));
-            $this->command = explode('@',substr($this->message, 1, $space-1))[0];
+            $this->command = explode('@', substr($this->message, 1, $space-1))[0];
             $this->commandArgs = $args === [''] ? [] : $args;
         } else {
             $this->command = null;

--- a/src/EventHandler/Message/Entities/TextWithEntities.php
+++ b/src/EventHandler/Message/Entities/TextWithEntities.php
@@ -64,8 +64,8 @@ final class TextWithEntities implements JsonSerializable
             return StrTools::htmlEscape($this->text);
         }
         if ($allowTelegramTags) {
-            return $this->htmlTelegram ??= StrTools::entitiesToHtml($this->text, MessageEntity::fromRawEntities($this->entities), $allowTelegramTags);
+            return $this->htmlTelegram ??= StrTools::entitiesToHtml($this->text, $this->entities, $allowTelegramTags);
         }
-        return $this->html ??= StrTools::entitiesToHtml($this->text, MessageEntity::fromRawEntities($this->entities), $allowTelegramTags);
+        return $this->html ??= StrTools::entitiesToHtml($this->text, $this->entities, $allowTelegramTags);
     }
 }


### PR DESCRIPTION
- Add support for `/command@usernamebot` commands structure as single command
- Fix as entities property is list of message there is no need to convert it again in TextWithEntitiesClass