### PR TITLE
Fix: error during file download causes client infinite wait

### DIFF
--- a/src/MTProtoTools/FilesLogic.php
+++ b/src/MTProtoTools/FilesLogic.php
@@ -31,6 +31,7 @@ use Amp\Http\Server\Request as ServerRequest;
 use Amp\Http\Server\Response;
 use Amp\Sync\LocalMutex;
 use Amp\Sync\Lock;
+use Amp\TimeoutCancellation;
 use danog\MadelineProto\API;
 use danog\MadelineProto\BotApiFileId;
 use danog\MadelineProto\EventHandler\Media;
@@ -237,16 +238,36 @@ trait FilesLogic
         );
 
         $body = null;
-        if ($result->shouldServe()) {
-            $pipe = new Pipe(1024 * 1024);
-            [$start, $end] = $result->getServeRange();
-            EventLoop::queue($this->downloadToStream(...), $messageMedia, $pipe->getSink(), $cb, $start, $end, $cancellation);
-            $body = $pipe->getSource();
-        } elseif (!\in_array($result->getCode(), [HttpStatus::OK, HttpStatus::PARTIAL_CONTENT], true)) {
-            $body = $result->getCodeExplanation();
-        }
+        try {
+            if ($result->shouldServe()) {
+                [$start, $end] = $result->getServeRange();
 
-        return new Response($result->getCode(), $result->getHeaders(), $body);
+                $checkTimeout = new TimeoutCancellation(5.0);
+                $pipeTemp = new Pipe(1);
+                $this->downloadToStream($messageMedia, $pipeTemp->getSink(), null, $start, $start + 1, $checkTimeout);
+                $pipeTemp->getSink()->close();
+                if (strlen($pipeTemp->getSource()->read($checkTimeout)) !== 1) {
+                    throw new Exception('Cant download file from telegram server');
+                }
+
+                $pipe = new Pipe(1024 * 1024);
+                EventLoop::queue(function () use ($messageMedia, $pipe, $cb, $start, $end, $cancellation, $request): void {
+                    try {
+                        $this->downloadToStream($messageMedia, $pipe->getSink(), $cb, $start, $end, $cancellation);
+                    } catch (\Throwable $e) {
+                        $this->logger->logger($e, Logger::ERROR);
+                    }
+                    $pipe->getSink()->close();
+                });
+                $body = $pipe->getSource();
+            } elseif (!\in_array($result->getCode(), [HttpStatus::OK, HttpStatus::PARTIAL_CONTENT], true)) {
+                $body = $result->getCodeExplanation();
+            }
+
+            return new Response($result->getCode(), $result->getHeaders(), $body);
+        } catch (\Throwable $e) {
+            return new Response(HttpStatus::INTERNAL_SERVER_ERROR, [], $e->getMessage() . PHP_EOL);
+        }
     }
 
     /**


### PR DESCRIPTION
Currently client will wait indefinitely, even if error is occured in first chunk. 

This is happening because Content-Length is provided and then data is streamed asyncronosly. 

To fix this i added small healthcheck before async download. 

Test: 

```
curl --location --request POST 'http://127.0.0.1:9503/api/downloadToResponse/' --header 'Content-Type: application/json' --data-raw '{"media":{"size":41353,"fileName":"5357212549566818370_c_2.jpg","fileExt":".jpg","creationDate":1741329077,"mimeType":"image\/jpeg","ttl":null,"spoiler":false,"botApiFileId":"AgACAgIAAxUAAWgl5AZcoS8rAAHMreoYk24yNftkfQACQugxG26kWEoNGKMvPjV1QAEAAwIAA2MAAy8E","botApiFileUniqueId":"AQADQugxG26kWEoB","encrypted":false,"thumb":null,"thumbHeight":null,"thumbWidth":null,"protected":false,"hasStickers":false}}' -v
```

Before: infinite client wait/hangup.
After: Return immediately with code 500 and response: `FILE_REFERENCE_EXPIRED`