### PR TITLE
Fix: getInputClientProxy on null

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -237,6 +237,10 @@ final class Connection
      */
     public function getInputClientProxy(): ?array
     {
+        if ($this->chosenCtx === null) {
+            $this->connect();
+        }
+        Assert::notNull($this->chosenCtx);
         return $this->chosenCtx->getInputClientProxy();
     }
     /**


### PR DESCRIPTION
Fixes error Error: Call to a member function getInputClientProxy() on null in /app/vendor/danog/madelineproto/src/Connection.php:240:

```
[2026-06-20 02:07:01] [warning] 
Starting MadelineProto...
 
[2026-06-20 02:07:01] [notice] MadelineProto 8.7.0 
[2026-06-20 02:07:01] [notice] Copyright (C) 2016-2026 Daniil Gentili 
[2026-06-20 02:07:01] [notice] Licensed under AGPLv3 
[2026-06-20 02:07:01] [notice] https://github.com/danog/MadelineProto 
[2026-06-20 02:07:01] [notice] Got exclusive session lock! 
[2026-06-20 02:07:01] [notice] Extracting session from database... 
PsrLogger, 5513719274:      	Total client connections are limited to 1000.
PsrLogger, 5513719274:      	Client connections are limited to 10 per IP address (excluding localhost).
PsrLogger, 5513719274:      	Request concurrency limited to 1000 simultaneous requests
PsrLogger, 5513719274:      	Request methods restricted to GET, POST, PUT, PATCH, HEAD, OPTIONS, DELETE.
[2026-06-20 02:07:02] [warning] The prometheus settings have changed! 
[2026-06-20 02:07:02] [notice] Total client connections are limited to 1000. 
[2026-06-20 02:07:02] [notice] Client connections are limited to 10 per IP address (excluding localhost). 
[2026-06-20 02:07:02] [notice] Request concurrency limited to 1000 simultaneous requests 
[2026-06-20 02:07:02] [notice] Request methods restricted to GET, POST, PUT, PATCH, HEAD, OPTIONS, DELETE. 
[2026-06-20 02:07:02] [warning] Connecting to DC 2 
[2026-06-20 02:07:02] [notice] Restoring 0 messages to DC 2 
[2026-06-20 02:07:02] [warning] Resetting session in DC 2.0 due to creating initial session... 
[2026-06-20 02:07:02] [warning] Connecting to DC 2.0 via tcp://149.154.167.41:443 main DC 2, via ipv4 using AbridgedStream => BufferedRawStream => DefaultStream  
[2026-06-20 02:07:02] [notice] Handling auth key transition to ENCRYPTED in DC 2 
[2026-06-20 02:07:02] [notice] Finished auth key transition to ENCRYPTED in DC 2 
[2026-06-20 02:07:02] [notice] Resumed update feed loop generic 
[2026-06-20 02:07:02] [warning] Connected to DC 2.0 via tcp://149.154.167.41:443 main DC 2, via ipv4 using AbridgedStream => BufferedRawStream => DefaultStream! 
[2026-06-20 02:07:02] [warning] Connecting to DC 4 
[2026-06-20 02:07:02] [notice] Restoring 0 messages to DC 4 
[2026-06-20 02:07:02] [warning] Resetting session in DC 4.0 due to creating initial session... 
[2026-06-20 02:07:02] [warning] Connecting to DC 4.0 via tcp://149.154.167.92:443 main DC 4, via ipv4 using AbridgedStream => BufferedRawStream => DefaultStream  
Error: Call to a member function getInputClientProxy() on null in /app/vendor/danog/madelineproto/src/Connection.php:240
Stack trace:
#0 /app/vendor/danog/madelineproto/src/DataCenterConnection.php(246): danog\MadelineProto\Connection->getInputClientProxy()
#1 /app/vendor/danog/madelineproto/src/DataCenterConnection.php(134): danog\MadelineProto\DataCenterConnection->initAuthorization(danog\MadelineProto\MTProto\ConnectionState::ENCRYPTED_NOT_INITED)
#2 /app/vendor/danog/madelineproto/src/Reactive/SimpleSubscriberAdaptor.php(45): danog\MadelineProto\DataCenterConnection->onSimpleStateChange(danog\MadelineProto\MTProto\ConnectionState::ENCRYPTED_NOT_INITED)
#3 /app/vendor/danog/madelineproto/src/Reactive/Actor.php(59): danog\MadelineProto\Reactive\SimpleSubscriberAdaptor->onStateChange(danog\MadelineProto\MTProto\ConnectionState::ENCRYPTED_NOT_BOUND, danog\MadelineProto\MTProto\ConnectionState::ENCRYPTED_NOT_INITED)
#4 /app/vendor/danog/loop/lib/GenericLoop.php(55): danog\MadelineProto\Reactive\Actor->{closure:danog\MadelineProto\Reactive\Actor::__wakeup():54}(Object(danog\Loop\GenericLoop))
#5 /app/vendor/danog/loop/lib/Loop.php(139): danog\Loop\GenericLoop->loop()
#6 /app/vendor/danog/loop/lib/Loop.php(251): danog\Loop\Loop->loopInternal()
#7 /app/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(629): danog\Loop\Loop->{closure:danog\Loop\Loop::resume():249}('fk')
#8 [internal function]: Revolt\EventLoop\Internal\AbstractDriver->{closure:Revolt\EventLoop\Internal\AbstractDriver::createCallbackFiber():593}()
#9 /app/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(525): Fiber->resume()
#10 /app/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(586): Revolt\EventLoop\Internal\AbstractDriver->invokeCallbacks()
#11 [internal function]: Revolt\EventLoop\Internal\AbstractDriver->{closure:Revolt\EventLoop\Internal\AbstractDriver::createLoopFiber():566}()
#12 /app/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(96): Fiber->resume()
[2026-06-20 02:07:03] [notice] Handling auth key transition to ENCRYPTED_NOT_INITED in DC 4 
[2026-06-20 02:07:03] [notice] Writing client info (also executing help.getConfig)... 
```