### PR TITLE
Fix: null message during connect to CDN

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -554,7 +554,7 @@ final class Connection
             $message->setSerializedBody($body);
             unset($body);
         }
-        $this->connect();
+        $this->createSession();
         $this->pendingOutgoingGauge?->inc();
         if ($message->unencrypted) {
             $this->unencryptedPendingOutgoing->enqueue($message);
@@ -563,6 +563,7 @@ final class Connection
         } else {
             $this->mainPendingOutgoing->enqueue($message);
         }
+        $this->connect();
         $this->flush();
     }
     /**


### PR DESCRIPTION
DataCenterConnection::initAuthorization() needs message to init CDN connection:

log: 
```
[2026-06-24 13:34:09] [notice] File is stored on CDN! 
[2026-06-24 13:34:09] [warning] Connecting to DC 203 
[2026-06-24 13:34:09] [notice] Restoring 0 messages to DC 203 
[2026-06-24 13:34:09] [warning] Resetting session in DC 203.0 due to creating initial session... 
[2026-06-24 13:34:09] [warning] Connecting to DC 203.0 via tcp://91.105.192.100:443 main DC 203, via ipv4 using AbridgedStream => BufferedRawStream => DefaultStream  
[2026-06-24 13:34:10] [notice] Handling auth key transition to ENCRYPTED_NOT_INITED in DC 203 
[2026-06-24 13:34:10] [notice] Writing client info (also executing help.getConfig)... 
[2026-06-24 13:34:10] [critical] Webmozart\Assert\InvalidArgumentException: Expected a value other than null. in /app/vendor/webmozart/assert/src/Assert.php:2338
Stack trace:
#0 /app/vendor/webmozart/assert/src/Assert.php(710): Webmozart\Assert\Assert::reportInvalidArgument('Expected a valu...')
#1 /app/vendor/danog/madelineproto/src/DataCenterConnection.php(225): Webmozart\Assert\Assert::notNull(NULL)
#2 /app/vendor/danog/madelineproto/src/DataCenterConnection.php(134): danog\MadelineProto\DataCenterConnection->initAuthorization(danog\MadelineProto\MTProto\ConnectionState::ENCRYPTED_NOT_INITED)
#3 /app/vendor/danog/madelineproto/src/Reactive/SimpleSubscriberAdaptor.php(45): danog\MadelineProto\DataCenterConnection->onSimpleStateChange(danog\MadelineProto\MTProto\ConnectionState::ENCRYPTED_NOT_INITED)
#4 /app/vendor/danog/madelineproto/src/Reactive/Actor.php(59): danog\MadelineProto\Reactive\SimpleSubscriberAdaptor->onStateChange(danog\MadelineProto\MTProto\ConnectionState::UNENCRYPTED, danog\MadelineProto\MTProto\ConnectionState::ENCRYPTED_NOT_INITED)
#5 /app/vendor/danog/loop/lib/GenericLoop.php(55): danog\MadelineProto\Reactive\Actor->{closure:danog\MadelineProto\Reactive\Actor::__wakeup():54}(Object(danog\Loop\GenericLoop))
#6 /app/vendor/danog/loop/lib/Loop.php(139): danog\Loop\GenericLoop->loop()
#7 /app/vendor/danog/loop/lib/Loop.php(251): danog\Loop\Loop->loopInternal()
#8 /app/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(629): danog\Loop\Loop->{closure:danog\Loop\Loop::resume():249}('aktp')
#9 [internal function]: Revolt\EventLoop\Internal\AbstractDriver->{closure:Revolt\EventLoop\Internal\AbstractDriver::createCallbackFiber():593}()
#10 /app/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(530): Fiber->start()
#11 /app/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(586): Revolt\EventLoop\Internal\AbstractDriver->invokeCallbacks()
#12 [internal function]: Revolt\EventLoop\Internal\AbstractDriver->{closure:Revolt\EventLoop\Internal\AbstractDriver::createLoopFiber():566}()
#13 /app/vendor/revolt/event-loop/src/EventLoop/Internal/AbstractDriver.php(96): Fiber->resume()
#14 /app/vendor/revolt/event-loop/src/EventLoop/Internal/DriverSuspension.php(119): Revolt\EventLoop\Internal\AbstractDriver->{closure:Revolt\EventLoop\Internal\AbstractDriver::__construct():90}()
#15 /app/vendor/amphp/amp/src/functions.php(115): Revolt\EventLoop\Internal\DriverSuspension->suspend()
#16 /app/src/Server/Server.php(63): Amp\trapSignal(Array)
#17 /app/src/Server/Server.php(49): TelegramApiServer\Server\Server::registerShutdown(Object(Amp\Http\Server\SocketHttpServer))
#18 /app/server.php(92): TelegramApiServer\Server\Server->__construct(Array, Array)
#19 {main}

```